### PR TITLE
fixed jmh import for Build.scala/build.sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,16 @@ And then create a new project in your build, to which you should add the jmhSett
 For example create another directory with `build.sbt` in it, and paste:
 
 ```scala
-import pl.project13.scala.sbt.SbtJmh._
-
 jmhSettings
 ```
+
+If you're using a `project/Build.scala`-style build file, you should instead write:
+
+```scala
+import pl.project13.scala.sbt.SbtJmh._
+```
+
+and then add jmhSettings as a setting to a `Project`.
 
 Write your benchmarks in `src/main/scala`. They will be picked up and instrumented by the plugin.
 


### PR DESCRIPTION
Problem

I found empirically that the package named in the README.md was incorrect

Result

README is more correct, it's easier to get up and running with sbt-jmh.
