### PR TITLE
Make the JMH plugin only regenerate and recompile on source changes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalacOptions ++= List(
   "-unchecked",
   "-deprecation",
   "-language:_",
-  "-target:jvm-1.7",
+  "-target:jvm-1.6",
   "-encoding", "UTF-8"
 )
 

--- a/src/sbt-test/sbt-jmh/custom-runner/build.sbt
+++ b/src/sbt-test/sbt-jmh/custom-runner/build.sbt
@@ -1,2 +1,2 @@
 enablePlugins(JmhPlugin)
-mainClass in (Compile, run) := Some("com.example.CustomRunnerApp")
+mainClass in (Jmh, run) := Some("com.example.CustomRunnerApp")

--- a/src/sbt-test/sbt-jmh/custom-runner/test
+++ b/src/sbt-test/sbt-jmh/custom-runner/test
@@ -1,5 +1,5 @@
 # compile jmh sources all the way to ready to run bench class files
-> run -i 1 -wi 1 -f 1 .*Hello.*
+> jmh:run -i 1 -wi 1 -f 1 .*Hello.*
 
 # check if the custom file was generated
 $ exists custom.out

--- a/src/sbt-test/sbt-jmh/jmh-asm/test
+++ b/src/sbt-test/sbt-jmh/jmh-asm/test
@@ -1,5 +1,5 @@
 # compile jmh sources all the way to ready to run bench class files
-> run -i 1 -wi 1 -f 1 -rf csv .*Hello.*
+> jmh:run -i 1 -wi 1 -f 1 -rf csv .*Hello.*
 
 # check if the csv file was generated
 $ exists jmh-result.csv

--- a/src/sbt-test/sbt-jmh/run/test
+++ b/src/sbt-test/sbt-jmh/run/test
@@ -1,5 +1,5 @@
 # compile jmh sources all the way to ready to run bench class files
-> run -i 1 -wi 1 -f 1 -rf csv .*Hello.*
+> jmh:run -i 1 -wi 1 -f 1 -rf csv .*Hello.*
 
 # check if the csv file was generated
 $ exists jmh-result.csv

--- a/src/sbt-test/sbt-jmh/runMain/test
+++ b/src/sbt-test/sbt-jmh/runMain/test
@@ -1,5 +1,5 @@
 # use the given class as runner
-> runMain com.example.CustomRunnerApp -i 1 -wi 1 -f 1 .*Hello.*
+> jmh:runMain com.example.CustomRunnerApp -i 1 -wi 1 -f 1 .*Hello.*
 
 # check if the custom file was generated
 $ exists custom.out

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.2"
+version in ThisBuild := "0.2.3-SNAPSHOT"


### PR DESCRIPTION
* Made the JMH scope inherit Test to automatically get the benhcmark code on the path to avoid the special compile step and not write to the same class files directory
* Cached the generation of sources and resources
* Use sourceGenerators and resourceGenerators
* All interactions with JMH are now scoped to jmh:*