### PR TITLE
Fix FlightRecorder profiler on fork 2 and above

### DIFF
--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
@@ -71,14 +71,11 @@ public class FlightRecordingProfiler implements ExternalProfiler {
   @Override
   public Collection<String> addJVMOptions(BenchmarkParams params) {
 
-    startFlightRecordingOptions += "filename=" + jfrData;
-    flightRecorderOptions += "settings=" + params.getJvm().replace("bin/java", "lib/jfr/profile.jfc");
-
     return Arrays.asList(
       "-XX:+UnlockCommercialFeatures",
       "-XX:+FlightRecorder",
-      "-XX:StartFlightRecording=" + startFlightRecordingOptions,
-      "-XX:FlightRecorderOptions=" + flightRecorderOptions);
+      "-XX:StartFlightRecording=" + startFlightRecordingOptions + "filename=" + jfrData;,
+      "-XX:FlightRecorderOptions=" + "settings=" + params.getJvm().replace("bin/java", "lib/jfr/profile.jfc");
   }
 
   @Override


### PR DESCRIPTION
Fixes:

```
[info] [jfr][WARN ][0.064] java.io.FileNotFoundException:/Library/Java/JavaVirtualMachines/jdk1.8.0_91.jdk/Contents/Home/jre/lib/jfr/profile.jfcsettings=/Library/Java/JavaVirtualMachines/jdk1.8.0_91.jdk/Contents/Home/jre/lib/jfr/profile.jfc (No such file or directory)
```