### PR TITLE
Fix for #85

### DIFF
--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
@@ -71,14 +71,11 @@ public class FlightRecordingProfiler implements ExternalProfiler {
   @Override
   public Collection<String> addJVMOptions(BenchmarkParams params) {
 
-    startFlightRecordingOptions += "filename=" + jfrData;
-    flightRecorderOptions += "settings=" + params.getJvm().replace("bin/java", "lib/jfr/profile.jfc");
-
     return Arrays.asList(
       "-XX:+UnlockCommercialFeatures",
       "-XX:+FlightRecorder",
       "-XX:StartFlightRecording=" + startFlightRecordingOptions + "filename=" + jfrData,
-      "-XX:FlightRecorderOptions=" + "settings=" + params.getJvm().replace("bin/java", "lib/jfr/profile.jfc"));
+      "-XX:FlightRecorderOptions=" + flightRecorderOptions + "settings=" + params.getJvm().replace("bin/java", "lib/jfr/profile.jfc"));
   }
 
   @Override


### PR DESCRIPTION
Fix setting FlightRecorderOptions by appending them just once. Before this
fix, they were added multiple times due to mutation of
`startFlighRecordingOptions`. Mutable code is hard!

Fixes #85