### PR TITLE
Upgrade to JMH version 1.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The latest published plugin version is: [![Download](https://api.bintray.com/pac
 
 | Plugin version         | Shipped JMH version                   | 
 | ---------------------- |:-------------------------------------:| 
+| `0.2.16` (auto plugin) | `1.14.1`                              |
 | `0.2.15` (auto plugin) | `1.14`                                |
 | `0.2.11` (auto plugin) | `1.13`                                |
 | `0.2.10` (auto plugin) | `1.12` (added `-prof jmh.extras.JFR`) |
@@ -55,7 +56,7 @@ your project is to add the below line to your `project/plugins.sbt` file:
 
 ```scala
 // project/plugins.sbt
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.15")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.16")
 ```
 
 and enable it in the projects where you want to (useful in multi-project builds, as you can enable it only where you need it):

--- a/notes/0.2.16.markdown
+++ b/notes/0.2.16.markdown
@@ -1,0 +1,1 @@
+- Bumped JMH dependency to 1.14.1.

--- a/plugin/src/main/resources/sbt-jmh.properties
+++ b/plugin/src/main/resources/sbt-jmh.properties
@@ -1,2 +1,2 @@
-jmh.version=1.14
-extras.version=0.2.15
+jmh.version=1.14.1
+extras.version=0.2.16

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.15"
+version in ThisBuild := "0.2.16"


### PR DESCRIPTION
Sorry for pushing you but it'd be glad if you could publish sbt-jmh to maven repo (if you have time!) :) 
If I'm correct the upcoming sbt-jmh plugin version is 0.2.16? 

P.S.
If you think it'd be better for us to wait for JMH 1.15 release. Let's wait! :D Please close this PR if so :)

ref. http://mail.openjdk.java.net/pipermail/jmh-dev/2016-September/002351.html