### PR TITLE
Upgrade to JMH version 1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The latest published plugin version is: [![Download](https://api.bintray.com/pac
 
 | Plugin version         | Shipped JMH version                   | 
 | ---------------------- |:-------------------------------------:| 
+| `0.2.17` (auto plugin) | `1.15`                                |
 | `0.2.16` (auto plugin) | `1.14.1`                              |
 | `0.2.15` (auto plugin) | `1.14`                                |
 | `0.2.11` (auto plugin) | `1.13`                                |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The latest published plugin version is: [![Download](https://api.bintray.com/pac
 
 | Plugin version         | Shipped JMH version                   | 
 | ---------------------- |:-------------------------------------:| 
-| `0.2.17` (auto plugin) | `1.15`                                |
+| `0.2.17` (auto plugin) | `1.16`                                |
 | `0.2.16` (auto plugin) | `1.14.1`                              |
 | `0.2.15` (auto plugin) | `1.14`                                |
 | `0.2.11` (auto plugin) | `1.13`                                |

--- a/notes/0.2.17.markdown
+++ b/notes/0.2.17.markdown
@@ -1,0 +1,1 @@
+- Bumped JMH dependency to 1.15.

--- a/notes/0.2.17.markdown
+++ b/notes/0.2.17.markdown
@@ -1,1 +1,1 @@
-- Bumped JMH dependency to 1.15.
+- Bumped JMH dependency to 1.16.

--- a/plugin/src/main/resources/sbt-jmh.properties
+++ b/plugin/src/main/resources/sbt-jmh.properties
@@ -1,2 +1,2 @@
-jmh.version=1.15
+jmh.version=1.16
 extras.version=0.2.17

--- a/plugin/src/main/resources/sbt-jmh.properties
+++ b/plugin/src/main/resources/sbt-jmh.properties
@@ -1,2 +1,2 @@
-jmh.version=1.14.1
-extras.version=0.2.16
+jmh.version=1.15
+extras.version=0.2.17

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.16"
+version in ThisBuild := "0.2.17"


### PR DESCRIPTION
Bump JMH version from 1.14.1 to 1.15.

This new version comes with bug fixes on `@Group` and `@Setup` and some
enhancements for `@AuxCounters`.

See http://mail.openjdk.java.net/pipermail/jmh-dev/2016-September/002371.html
for the full release announcement.

Fix #90