### PR TITLE
Cross-compile the plugin against 0.13.15 and 1.0.0-M6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 sudo: false
 language: scala
 script: sbt '; extras/publishLocal; ^scripted'
+jdk:
+ - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 sudo: false
 language: scala
-script: sbt ';publishLocal; scripted'
+script: sbt '; extras/publishLocal; ^scripted'

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ sourceDirectory in Jmh := (sourceDirectory in Test).value
 classDirectory in Jmh := (classDirectory in Test).value
 dependencyClasspath in Jmh := (dependencyClasspath in Test).value
 // rewire tasks, so that 'jmh:run' automatically invokes 'jmh:compile' (otherwise a clean 'jmh:run' would fail)
-compile in Jmh <<= (compile in Jmh) dependsOn (compile in Test)
-run in Jmh <<= (run in Jmh) dependsOn (Keys.compile in Jmh)
+compile in Jmh := (compile in Jmh).dependsOn(compile in Test).value
+run in Jmh := (run in Jmh).dependsOn(Keys.compile in Jmh).value
 ```
 
 Options

--- a/build.sbt
+++ b/build.sbt
@@ -32,9 +32,9 @@ val sonatypeSettings: Seq[Setting[_]] = Seq(
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
-  publishTo <<= version { (v: String) =>
+  publishTo := {
     val nexus = "https://oss.sonatype.org/"
-    if (v.trim.endsWith("SNAPSHOT"))
+    if (version.value.trim.endsWith("SNAPSHOT"))
       Some("snapshots" at nexus + "content/repositories/snapshots")
     else
       Some("releases" at nexus + "service/local/staging/deploy/maven2")
@@ -67,9 +67,9 @@ val sonatypeSettings: Seq[Setting[_]] = Seq(
     </parent>
   )
 
-// publishing settings
+// sbt-scripted settings
 val myScriptedSettings = scriptedSettings ++ Seq(
-  scriptedLaunchOpts <+= version(v => s"-Dproject.version=$v")
+  scriptedLaunchOpts += s"-Dproject.version=${version.value}"
 ) 
 
 val _crossVersions = Seq(
@@ -94,10 +94,12 @@ lazy val plugin = project
   .settings(
     name := "sbt-jmh",
     
-    // plugin publishing settings
     sbtPlugin := true,
-    publishTo <<= isSnapshot { snapshot =>
-      if (snapshot) Some(Classpaths.sbtPluginSnapshots) else Some(Classpaths.sbtPluginReleases)
+    publishTo := {
+      if (isSnapshot.value)
+        Some(Classpaths.sbtPluginSnapshots)
+      else
+        Some(Classpaths.sbtPluginReleases)
     },
     publishMavenStyle := false,
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
@@ -115,5 +117,4 @@ lazy val extras = project
     name := "sbt-jmh-extras",
     autoScalaLibrary := false, // it is plain Java
     crossPaths := false // it is plain Java
-    // publishing settings
   )

--- a/build.sbt
+++ b/build.sbt
@@ -13,12 +13,12 @@ val jmhVersion = {
 val commonSettings = Seq(
   organization := "pl.project13.scala",
 
-  scalaVersion := "2.10.6",
+  crossSbtVersions := Vector("0.13.15", "1.0.0-M5"),
+
   scalacOptions ++= List(
     "-unchecked",
     "-deprecation",
     "-language:_",
-    "-target:jvm-1.6",
     "-encoding", "UTF-8"
   ),
 
@@ -72,19 +72,12 @@ val myScriptedSettings = scriptedSettings ++ Seq(
   scriptedLaunchOpts += s"-Dproject.version=${version.value}"
 ) 
 
-val _crossVersions = Seq(
-  "2.10.6", 
-  "2.11.11",
-  "2.12.2"
-)
-
 // ---------------------------------------------------------------------------------------------------------------------
 
 lazy val root =
   project
     .in(file("."))
     .settings(commonSettings: _*)
-    .settings(crossScalaVersions := _crossVersions)
     .aggregate(plugin, extras)
 
 lazy val plugin = project
@@ -115,6 +108,7 @@ lazy val extras = project
   .settings(sonatypeSettings: _*)
   .settings(
     name := "sbt-jmh-extras",
+    scalaVersion := "2.12.2",
     autoScalaLibrary := false, // it is plain Java
     crossPaths := false // it is plain Java
   )

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,52 @@ val sonatypeSettings: Seq[Setting[_]] = Seq(
 
 // sbt-scripted settings
 val myScriptedSettings = scriptedSettings ++ Seq(
-  scriptedLaunchOpts += s"-Dproject.version=${version.value}"
+  scriptedLaunchOpts += s"-Dproject.version=${version.value}",
+
+  // Temporary fix for issue sbt/sbt/issues/3245
+  scripted := {
+    val args = ScriptedPlugin.asInstanceOf[{
+      def scriptedParser(f: File): complete.Parser[Seq[String]]
+    }].scriptedParser(sbtTestDirectory.value).parsed
+    val prereq: Unit = scriptedDependencies.value
+    try {
+      if((sbtVersion in pluginCrossBuild).value == "1.0.0-M6") {
+        ScriptedPlugin.scriptedTests.value.asInstanceOf[{
+          def run(
+                   x1: File,
+                   x2: Boolean,
+                   x3: Array[String],
+                   x4: File,
+                   x5: Array[String],
+                   x6: java.util.List[File]
+                 ): Unit
+        }].run(
+          sbtTestDirectory.value,
+          scriptedBufferLog.value,
+          args.toArray,
+          sbtLauncher.value,
+          scriptedLaunchOpts.value.toArray,
+          new java.util.ArrayList()
+        )
+      } else {
+        ScriptedPlugin.scriptedTests.value.asInstanceOf[{
+          def run(
+                   x1: File,
+                   x2: Boolean,
+                   x3: Array[String],
+                   x4: File,
+                   x5: Array[String]
+                 ): Unit
+        }].run(
+          sbtTestDirectory.value,
+          scriptedBufferLog.value,
+          args.toArray,
+          sbtLauncher.value,
+          scriptedLaunchOpts.value.toArray
+        )
+      }
+    } catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+  }
 ) 
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val jmhVersion = {
 val commonSettings = Seq(
   organization := "pl.project13.scala",
 
-  crossSbtVersions := Vector("0.13.15", "1.0.0-M5"),
+  crossSbtVersions := Vector("0.13.15", "1.0.0-M6"),
 
   scalacOptions ++= List(
     "-unchecked",

--- a/plugin/src/main/resources/sbt-jmh.properties
+++ b/plugin/src/main/resources/sbt-jmh.properties
@@ -1,2 +1,2 @@
 jmh.version=1.19
-extras.version=0.2.25
+extras.version=0.2.26-SNAPSHOT

--- a/plugin/src/sbt-test/sbt-jmh/custom-runner/src/main/scala/com/example/CustomRunnerApp.scala
+++ b/plugin/src/sbt-test/sbt-jmh/custom-runner/src/main/scala/com/example/CustomRunnerApp.scala
@@ -6,20 +6,21 @@ import org.openjdk.jmh.results.RunResult
 import org.openjdk.jmh.runner.Runner
 import org.openjdk.jmh.runner.options.CommandLineOptions
 
-object CustomRunnerApp extends App {
+object CustomRunnerApp {
   import scala.collection.JavaConversions._
 
-  val opts = new CommandLineOptions(args: _*) // parse command line arguments, and then bend them to your will! ;-)
+  def main(args: Array[String]): Unit = {
+    val opts = new CommandLineOptions(args: _*) // parse command line arguments, and then bend them to your will! ;-)
 
-  val runner = new Runner(opts) // full access to all JMH features, you can also provide a custom output Format here
+    val runner = new Runner(opts) // full access to all JMH features, you can also provide a custom output Format here
 
-  val results = runner.run() // actually run the benchmarks
+    val results = runner.run() // actually run the benchmarks
 
-  val f = new FileOutputStream(new File("custom.out"))
-  results.foreach { result: RunResult ⇒
-    // usually you'd use these results to report into some external aggregation tool for example
-    f.write(s"custom reporting result: ${result.getAggregatedResult.getPrimaryResult}".getBytes("UTF-8"))
+    val f = new FileOutputStream(new File("custom.out"))
+    results.foreach { result: RunResult ⇒
+      // usually you'd use these results to report into some external aggregation tool for example
+      f.write(s"custom reporting result: ${result.getAggregatedResult.getPrimaryResult}".getBytes("UTF-8"))
+    }
+    f.close()
   }
-  f.close()
-
 }

--- a/plugin/src/sbt-test/sbt-jmh/runMain/src/main/scala/com/example/CustomRunnerApp.scala
+++ b/plugin/src/sbt-test/sbt-jmh/runMain/src/main/scala/com/example/CustomRunnerApp.scala
@@ -6,20 +6,21 @@ import org.openjdk.jmh.results.RunResult
 import org.openjdk.jmh.runner.Runner
 import org.openjdk.jmh.runner.options.CommandLineOptions
 
-object CustomRunnerApp extends App {
+object CustomRunnerApp {
   import scala.collection.JavaConversions._
 
-  val opts = new CommandLineOptions(args: _*) // parse command line arguments, and then bend them to your will! ;-)
+  def main(args: Array[String]): Unit = {
+    val opts = new CommandLineOptions(args: _*) // parse command line arguments, and then bend them to your will! ;-)
 
-  val runner = new Runner(opts) // full access to all JMH features, you can also provide a custom output Format here
+    val runner = new Runner(opts) // full access to all JMH features, you can also provide a custom output Format here
 
-  val results = runner.run() // actually run the benchmarks
+    val results = runner.run() // actually run the benchmarks
 
-  val f = new FileOutputStream(new File("custom.out"))
-  results.foreach { result: RunResult ⇒
-    // usually you'd use these results to report into some external aggregation tool for example
-    f.write(s"custom reporting result: ${result.getAggregatedResult.getPrimaryResult}".getBytes("UTF-8"))
+    val f = new FileOutputStream(new File("custom.out"))
+    results.foreach { result: RunResult ⇒
+      // usually you'd use these results to report into some external aggregation tool for example
+      f.write(s"custom reporting result: ${result.getAggregatedResult.getPrimaryResult}".getBytes("UTF-8"))
+    }
+    f.close()
   }
-  f.close()
-
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16-M1

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.25"
+version in ThisBuild := "0.2.26-SNAPSHOT"


### PR DESCRIPTION
This PR fixes #115. 

I had to update the two `CustomRunnerApp` in the scripted tests two use the `main()` method. I ran into the `IncompatibleClassChangeError` issue, changes fix #66.

Now you have to use `^ scripted` and `^ publishSigned` to cross-compile with the correct sbt version (see the [0.13.16-M1](https://github.com/sbt/sbt/releases/tag/v0.13.16-M1) release notes).