### PR TITLE
Add license header.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,11 +95,13 @@ lazy val plugin = project
         Some(Classpaths.sbtPluginReleases)
     },
     publishMavenStyle := false,
+    startYear := Some(2014),
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
     bintrayPublishSettings,
     repository in bintray := "sbt-plugins",
     bintrayOrganization in bintray := None
   ).dependsOn(extras)
+  .enablePlugins(AutomateHeaderPlugin)
 
 
 lazy val extras = project

--- a/plugin/src/main/scala/pl/project13/scala/sbt/JmhPlugin.scala
+++ b/plugin/src/main/scala/pl/project13/scala/sbt/JmhPlugin.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 pl.project13.scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pl.project13.scala.sbt
 
 import java.util.Properties

--- a/plugin/src/main/scala/pl/project13/scala/sbt/package.scala
+++ b/plugin/src/main/scala/pl/project13/scala/sbt/package.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 pl.project13.scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pl.project13.scala
 
 package object sbt {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "2.0.0")
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
I only added license header in `plugin` project without `extras` project because `extras` didn't specific license in `build.sbt`. I think we could move sbt-key - `licenses` to `commonSettings` to let all projects with Apache-2.0. Since JMH is used GPLv2 with Classpath exception as OpenJDK, I think it should be fine.