### PR TITLE
Support async-profiler, improve JFR profiler

### DIFF
--- a/extras/src/main/java/jmh/extras/Async.java
+++ b/extras/src/main/java/jmh/extras/Async.java
@@ -1,0 +1,11 @@
+package jmh.extras;
+
+import org.openjdk.jmh.profile.ProfilerException;
+import pl.project13.scala.jmh.extras.profiler.FlightRecordingProfiler;
+
+/** Convenience class for easy usage in terminal: `jmh:run -prof jmh.extras.Async */
+public class Async extends pl.project13.scala.jmh.extras.profiler.AsyncProfiler {
+  public Async(String initLine) throws ProfilerException {
+    super(initLine);
+  }
+}

--- a/extras/src/main/java/jmh/extras/JFR.java
+++ b/extras/src/main/java/jmh/extras/JFR.java
@@ -1,12 +1,13 @@
 package jmh.extras;
 
+import org.openjdk.jmh.profile.ProfilerException;
 import pl.project13.scala.jmh.extras.profiler.FlightRecordingProfiler;
 
 import java.io.IOException;
 
 /** Convenience class for easy usage in terminal: `jmh:run -prof jmh.extras.JFR */
 public class JFR extends FlightRecordingProfiler {
-  public JFR(String initLine) throws IOException {
+  public JFR(String initLine) throws ProfilerException {
     super(initLine);
   }
 }

--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/AsyncProfiler.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/AsyncProfiler.java
@@ -1,0 +1,197 @@
+package pl.project13.scala.jmh.extras.profiler;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.profile.InternalProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.runner.IterationType;
+import org.openjdk.jmh.util.Utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class AsyncProfiler implements InternalProfiler {
+
+    private static final String ASYNC_PROFILER_DIR = "ASYNC_PROFILER_DIR";
+
+    private static final String DEFAULT_EVENT = "cpu";
+    private static final long DEFAULT_FRAMEBUF = 8 * 1024 * 1024;
+    private final String event;
+    private final Directions directions;
+    private final Path asyncProfilerDir;
+    private final boolean threads;
+    private Path outputDir;
+    private boolean started;
+
+    private Path profiler;
+    private Path jattach;
+    private Long framebuf;
+    private int measurementIterationCount;
+    private Path flameGraphDir;
+    private Collection<? extends String> flameGraphOpts = Collections.emptyList();
+    private boolean verbose = false;
+    private List<Path> generated = new ArrayList<>();
+
+    public AsyncProfiler(String initLine) throws ProfilerException {
+        OptionParser parser = new OptionParser();
+        OptionSpec<String> outputDir = parser.accepts("dir", "Output directory").withRequiredArg().describedAs("directory").ofType(String.class);
+        OptionSpec<String> asyncProfilerDir = parser.accepts("asyncProfilerDir", "Location of clone of https://github.com/jvm-profiling-tools/async-profiler. Also can be provided as $" + ASYNC_PROFILER_DIR).withRequiredArg().ofType(String.class).describedAs("directory");
+        OptionSpec<String> event = parser.accepts("event", "Event to sample: cpu, alloc, lock, cache-misses etc.").withRequiredArg().ofType(String.class).defaultsTo("cpu");
+        OptionSpec<Long> framebuf = parser.accepts("framebuf", "Size of profiler framebuffer").withRequiredArg().ofType(Long.class).defaultsTo(DEFAULT_FRAMEBUF);
+        OptionSpec<Boolean> threads = parser.accepts("threads", "profile threads separately").withRequiredArg().ofType(Boolean.class).defaultsTo(false,true);
+        OptionSpec<Boolean> verbose = parser.accepts("verbose", "Output the sequence of commands").withRequiredArg().ofType(Boolean.class).defaultsTo(false);
+        OptionSpec<String> flameGraphOpts = parser.accepts("flameGraphOpts", "Options passed to FlameGraph.pl").withRequiredArg().withValuesSeparatedBy(',').ofType(String.class);
+        OptionSpec<Directions> flameGraphDirection = parser.accepts("flameGraphDirection", "Directions to generate flamegraphs").withRequiredArg().ofType(Directions.class).defaultsTo(Directions.values());
+        OptionSpec<String> flameGraphDir = ProfilerUtils.addFlameGraphDirOption(parser);
+
+
+        OptionSet options = ProfilerUtils.parseInitLine(initLine, parser);
+        if (options.has(event)) {
+            this.event = options.valueOf(event);
+        } else {
+            this.event = DEFAULT_EVENT;
+        }
+        if (options.has(framebuf)) {
+            this.framebuf = options.valueOf(framebuf);
+        } else {
+            this.framebuf = DEFAULT_FRAMEBUF;
+        }
+        if (options.has(outputDir)) {
+            this.outputDir = Paths.get(options.valueOf(outputDir));
+            createOutputDirectories();
+        }
+
+        if (options.has(flameGraphOpts)) {
+            this.flameGraphOpts = options.valuesOf(flameGraphOpts);
+        }
+        if (options.has(flameGraphDirection)) {
+            this.directions = options.valueOf(flameGraphDirection);
+        } else {
+            this.directions = Directions.BOTH;
+        }
+        if (options.has(threads)) {
+            this.threads = options.valueOf(threads);
+        } else {
+            this.threads = false;
+        }
+        if (options.has(verbose)) {
+            this.verbose = options.valueOf(verbose);
+        }
+        this.flameGraphDir = ProfilerUtils.findFlamegraphDir(flameGraphDir, options);
+        this.asyncProfilerDir = lookupAsyncProfilerHome(asyncProfilerDir, options);
+        Path build = this.asyncProfilerDir.resolve("build");
+        Path profiler1 = build.resolve("libasyncProfiler.so");
+        if (!Files.exists(profiler1)) {
+            throw new ProfilerException(profiler1 + " does not exist");
+        } else {
+            this.profiler = profiler1;
+            Path jattach1 = build.resolve("jattach");
+            if (!Files.exists(jattach1)) {
+                throw new ProfilerException(jattach1 + " does not exist");
+            } else {
+                this.jattach = jattach1;
+            }
+        }
+
+    }
+
+    private Path lookupAsyncProfilerHome(OptionSpec<String> asyncProfilerDir, OptionSet options) throws ProfilerException {
+        if (options.has(asyncProfilerDir)) {
+            return Paths.get(options.valueOf(asyncProfilerDir));
+        } else {
+            String env = System.getenv(ASYNC_PROFILER_DIR);
+            if (env == null) {
+                throw new ProfilerException("Location of async-profiler-dir must be set with environment variable ASYNC_PROFILER_DIR or corresponding profiler option");
+            }
+            return Paths.get(env);
+        }
+    }
+
+    private void createOutputDirectories() {
+        try {
+            Files.createDirectories(this.outputDir);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void beforeIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams) {
+        if (!started && iterationParams.getType() == IterationType.MEASUREMENT) {
+            String threadOpt = this.threads ? ",threads" : "";
+            profilerCommand(String.format("start,event=%s%s,framebuf=%d", event, threadOpt, framebuf));
+            started = true;
+        }
+    }
+
+    @Override
+    public Collection<? extends Result> afterIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams, IterationResult result) {
+        if (iterationParams.getType() == IterationType.MEASUREMENT) {
+            measurementIterationCount += 1;
+            if (measurementIterationCount == iterationParams.getCount()) {
+                if (outputDir == null) {
+                    outputDir = createTempDir(benchmarkParams.id().replaceAll("/", "-"));
+                }
+                Path collapsedPath = outputDir.resolve("collapsed-" + event.toLowerCase() + ".txt");
+                profilerCommand(String.format("stop,file=%s,collapsed", collapsedPath));
+                generated.add(collapsedPath);
+                Path summaryPath = outputDir.resolve("summary.txt");
+                profilerCommand(String.format("stop,file=%s,summary", summaryPath));
+                generated.add(summaryPath);
+                if (flameGraphDir != null) {
+                    if (EnumSet.of(Directions.FORWARD, Directions.BOTH).contains(directions)) {
+                        flameGraph(collapsedPath, Collections.emptyList(), "");
+                    }
+                    if (EnumSet.of(Directions.REVERSE, Directions.BOTH).contains(directions)) {
+                        flameGraph(collapsedPath, Arrays.asList("--reverse"), "-reverse");
+                    }
+                }
+            }
+        }
+
+        return Collections.singletonList(result());
+    }
+
+    private void flameGraph(Path collapsedPath, List<String> extra, String suffix) {
+        generated.add(ProfilerUtils.flameGraph(collapsedPath, extra, suffix, flameGraphDir, flameGraphOpts, outputDir, event, verbose));
+    }
+
+    private NoResult result() {
+        StringBuilder result = new StringBuilder();
+        for (Path path : generated) {
+            result.append("\n").append(path.toAbsolutePath().toString());
+        }
+        return new NoResult("async-profiler", result.toString());
+    }
+
+    private void profilerCommand(String command) {
+        long pid = Utils.getPid();
+
+        ProcessBuilder processBuilder = new ProcessBuilder(jattach.toAbsolutePath().toString(), String.valueOf(pid), "load", profiler.toAbsolutePath().toString(), "true", command);
+        if (verbose) {
+            processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        }
+        ProfilerUtils.startAndWait(processBuilder, verbose);
+    }
+
+    private Path createTempDir(String prefix) {
+        try {
+            return Files.createTempDirectory(prefix);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return "Profiling using async-profiler";
+    }
+}

--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/Directions.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/Directions.java
@@ -1,0 +1,5 @@
+package pl.project13.scala.jmh.extras.profiler;
+
+enum Directions {
+    BOTH, NONE, FORWARD, REVERSE
+}

--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
@@ -1,178 +1,321 @@
 /*
  * Originally imported from Jason Zaugg's: https://github.com/retronym/scala-jmh-suite/blob/master/src/main/java/scala/tools/nsc/benchmark/FlightRecordingProfiler.java
- * Scala is licensed under the [BSD 3-Clause License](http://opensource.org/licenses/BSD-3-Clause). 
+ * Scala is licensed under the [BSD 3-Clause License](http://opensource.org/licenses/BSD-3-Clause).
  */
 package pl.project13.scala.jmh.extras.profiler;
 
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
 import org.openjdk.jmh.profile.ExternalProfiler;
+import org.openjdk.jmh.profile.InternalProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
 import org.openjdk.jmh.results.BenchmarkResult;
-import org.openjdk.jmh.util.FileUtils;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.runner.IterationType;
+import org.openjdk.jmh.util.Utils;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.lang.management.ManagementFactory;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-
-import org.openjdk.jmh.results.*;
-
-import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
-// Effectively equivalent to passing jvm args to append for each benchmark. e.g.,
-//
-//@Fork(jvmArgsAppend =
-//{
-//  "-XX:+UnlockCommercialFeatures",
-//  "-XX:+FlightRecorder",
-//  "-XX:StartFlightRecording=duration=60s,filename=./profiling-data.jfr,name=profile,settings=profile",
-//  "-XX:FlightRecorderOptions=settings=./openjdk/jdk1.8.0/jre/lib/jfr/profile.jfc,samplethreads=true"
-//})
-
 /**
- * The flight recording profiler enables flight recording for benchmarks and starts recording right away.
+ * The flight recording profiler enables flight recording for benchmarks. Recording starts after warmup iterations
+ * are complete.
  */
-public class FlightRecordingProfiler implements ExternalProfiler {
+public class FlightRecordingProfiler implements InternalProfiler, ExternalProfiler {
 
-  private String startFlightRecordingOptions = "duration=120s,name=profile,settings=profile,";
-  private String flightRecorderOptions = "samplethreads=true,stackdepth=1024,";
+    private static final List<String> DEFAULT_FLIGHT_RECORDER_OPTIONS = Arrays.asList("settings=profile");
+    private static final String JFR_FLAME_GRAPH_DIR = "JFR_FLAME_GRAPH_DIR";
+    private static final String PROFILE_JFR = "profile.jfr";
+    private static final List<String> DEFEAULT_JFR_OPTS = Arrays.asList("--use-simple-names");
+    private static final int DEFAULT_STACK_DEPTH = 1024;
+    private final Path jfrFlameGraphDir;
+    private final Directions directions;
+    private final List<String> jfrFlameGraphOpts;
+    private final Path flameGraphDir;
+    private final boolean debugNonSafepoints;
+    private boolean verbose = false;
+    private List<String> flameGraphOpts;
+    private final List<JfrEventType> events;
 
-  /**
-   * Directory to contain all generated reports.
-   */
-  private final String SAVE_FLIGHT_OUTPUT_TO ;
+    private List<String> flightRecorderOptions;
 
-  /**
-   * Temporary location to record data
-   */
-  private final String jfrData;
+    private boolean warmupStarted;
+    private boolean started;
+    private int measurementIterationCount;
+    private Path outputDir;
+    private String name;
+    private int stackDepth;
+    private List<Path> generated = new ArrayList<>();
 
-  /**
-   * Holds whether recording is supported (checking the existence of the needed unlocking flag)
-   */
-  private static final boolean IS_SUPPORTED;
+    public FlightRecordingProfiler(String initLine) throws ProfilerException {
+        OptionParser parser = new OptionParser();
+        OptionSpec<String> outputDir = parser.accepts("dir").withRequiredArg().describedAs("Output directory").ofType(String.class);
+        OptionSpec<JfrEventType> event = parser.accepts("events").withRequiredArg().ofType(JfrEventType.class).withValuesSeparatedBy(',').defaultsTo(JfrEventType.values());
+        OptionSpec<Boolean> debugNonSafepoints = parser.accepts("debugNonSafepoints").withRequiredArg().ofType(Boolean.class).defaultsTo(true, false);
+        OptionSpec<Integer> stackDepth = parser.accepts("stackDepth").withRequiredArg().ofType(Integer.class).defaultsTo(DEFAULT_STACK_DEPTH);
+        OptionSpec<Boolean> verbose = parser.accepts("verbose", "Output the sequence of commands").withRequiredArg().ofType(Boolean.class).defaultsTo(false);
+        OptionSpec<String> flightRecorderOpts = parser.accepts("flightRecorderOpts").withRequiredArg().ofType(String.class).withValuesSeparatedBy(",");
+        OptionSpec<String> flameGraphDir = ProfilerUtils.addFlameGraphDirOption(parser);
+        OptionSpec<String> jfrFlameGraphDir = parser.accepts("jfrFlameGraphDir", "Location of clone of https://github.com/chrishantha/jfr-flame-graph. Also can be provided as $" + JFR_FLAME_GRAPH_DIR).withRequiredArg().ofType(String.class).describedAs("directory");
+        OptionSpec<String> jfrFlameGraphOpts = parser.accepts("jfrFlameGraphOpts", "Options passed to flamegraph-output.sh").withRequiredArg().withValuesSeparatedBy(',').ofType(String.class);
+        OptionSpec<String> flameGraphOpts = parser.accepts("flameGraphOpts", "Options passed to FlameGraph.pl").withRequiredArg().withValuesSeparatedBy(',').ofType(String.class);
+        OptionSpec<Directions> flameGraphDirection = parser.accepts("flameGraphDirection", "Directions to generate flamegraphs").withRequiredArg().ofType(Directions.class);
+        OptionSet options = ProfilerUtils.parseInitLine(initLine, parser);
 
-  static {
-    IS_SUPPORTED = ManagementFactory.getRuntimeMXBean().getInputArguments().contains("-XX:+UnlockCommercialFeatures");
-  }
-
-  public FlightRecordingProfiler(String initLine) throws IOException {
-    OptionParser parser = new OptionParser();
-    parser.accepts("dir").withRequiredArg().ofType(String.class);
-    OptionSet options = parser.parse(initLine);
-
-    if (options.hasArgument("dir")) {
-      SAVE_FLIGHT_OUTPUT_TO = (String) options.valueOf("dir");
-    } else {
-      SAVE_FLIGHT_OUTPUT_TO = System.getProperty("jmh.jfr.saveTo", ".");
-    }
-    jfrData = FileUtils.tempFile(".jfrData").getAbsolutePath();
-  }
-
-  @Override
-  public Collection<String> addJVMInvokeOptions(BenchmarkParams params) {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public Collection<String> addJVMOptions(BenchmarkParams params) {
-
-    return Arrays.asList(
-      "-XX:+UnlockCommercialFeatures",
-      "-XX:+FlightRecorder",
-      "-XX:StartFlightRecording=" + startFlightRecordingOptions + "filename=" + jfrData,
-      "-XX:FlightRecorderOptions=" + flightRecorderOptions + "settings=" + params.getJvm().replace("bin/java", "lib/jfr/profile.jfc"));
-  }
-
-  @Override
-  public void beforeTrial(BenchmarkParams benchmarkParams) {
-  }
-
-  static int currentId;
-
-  @Override
-  public Collection<? extends Result> afterTrial(BenchmarkResult benchmarkResult, long l, File stdOut, File stdErr) {
-    final String target = SAVE_FLIGHT_OUTPUT_TO + "/" + benchmarkResult.getParams().id().replaceAll("/", "-") + "-" + currentId++ + ".jfr";
-
-    final StringWriter sw = new StringWriter();
-    final PrintWriter pw = new PrintWriter(sw);
-
-    try {
-      FileUtils.copy(jfrData, target);
-      pw.println("Flight Recording output saved to: \n" +
-        "  " + new File(target).getAbsolutePath());
-    } catch (IOException e) {
-      pw.println("Unable to save flight output to: \n" +
-        "  " + new File(target).getAbsolutePath());
-    }
-
-    pw.flush();
-    pw.close();
-
-    final NoResult r = new NoResult(sw.toString());
-
-    return Collections.singleton(r);
-  }
-
-  @Override
-  public boolean allowPrintOut() {
-    return true;
-  }
-
-  @Override
-  public boolean allowPrintErr() {
-    return false;
-  }
-
-  // @Override
-  public boolean checkSupport(List<String> msgs) {
-    msgs.add("Commercial features of the JVM need to be enabled for this profiler.");
-    return IS_SUPPORTED;
-  }
-
-  @Override
-  public String getDescription() {
-    return "Java Flight Recording profiler runs for every benchmark.";
-  }
-
-  private class NoResult extends Result<NoResult> {
-    private final String output;
-
-    public NoResult(String output) {
-      super(ResultRole.SECONDARY, "JFR", of(Double.NaN), "N/A", AggregationPolicy.SUM);
-
-      this.output = output;
-    }
-
-    @Override
-    protected Aggregator<NoResult> getThreadAggregator() {
-      return new NoResultAggregator();
-    }
-
-    @Override
-    protected Aggregator<NoResult> getIterationAggregator() {
-      return new NoResultAggregator();
-    }
-
-    @Override
-    public String extendedInfo() {
-      return "JFR Messages:\n--------------------------------------------\n" + output;
-    }
-
-    private class NoResultAggregator implements Aggregator<NoResult> {
-      @Override
-      public NoResult aggregate(Collection<NoResult> results) {
-        String output = "";
-        for (NoResult r : results) {
-          output += r.output;
+        if (options.has(event)) {
+            this.events = options.valuesOf(event);
+        } else {
+            this.events = Arrays.asList(JfrEventType.CPU, JfrEventType.ALLOCATION_TLAB);
         }
-        return new NoResult(output);
-      }
+        if (options.has(outputDir)) {
+            this.outputDir = Paths.get(options.valueOf(outputDir));
+            createOutputDirectories();
+        } else {
+            String outputDirFromProp = System.getProperty("jmh.jfr.saveTo");
+            if (outputDirFromProp != null) {
+                this.outputDir = Paths.get(outputDirFromProp);
+                createOutputDirectories();
+            }
+            // else create later once we know the benchmark params
+        }
+        if (options.has(flightRecorderOpts)) {
+            this.flightRecorderOptions = options.valuesOf(flightRecorderOpts);
+        } else {
+            this.flightRecorderOptions = DEFAULT_FLIGHT_RECORDER_OPTIONS;
+        }
+        this.flameGraphDir = ProfilerUtils.findFlamegraphDir(flameGraphDir, options);
+        if (this.flameGraphDir != null) {
+            if (options.has(jfrFlameGraphDir)) {
+                this.jfrFlameGraphDir = Paths.get(options.valueOf(jfrFlameGraphDir));
+            } else {
+                String jfrFlameGraphHome = System.getenv(JFR_FLAME_GRAPH_DIR);
+                if (jfrFlameGraphHome != null) {
+                    this.jfrFlameGraphDir = Paths.get(jfrFlameGraphHome);
+                } else {
+                    this.jfrFlameGraphDir = null;
+                }
+            }
+        } else {
+            this.jfrFlameGraphDir = null;
+        }
+        if (options.has(flameGraphOpts)) {
+            this.flameGraphOpts = options.valuesOf(flameGraphOpts);
+        }
+        if (options.has(jfrFlameGraphOpts)) {
+            this.jfrFlameGraphOpts = options.valuesOf(jfrFlameGraphOpts);
+        } else {
+            this.jfrFlameGraphOpts = DEFEAULT_JFR_OPTS;
+        }
+        if (options.has(flameGraphDirection)) {
+            this.directions = options.valueOf(flameGraphDirection);
+        } else {
+            this.directions = Directions.BOTH;
+        }
+        if (options.has(debugNonSafepoints)) {
+            this.debugNonSafepoints = options.valueOf(debugNonSafepoints);
+        } else {
+            this.debugNonSafepoints = true;
+        }
+        if (options.has(stackDepth)) {
+            this.stackDepth = options.valueOf(stackDepth);
+        } else {
+            this.stackDepth = DEFAULT_STACK_DEPTH;
+        }
+        if (options.has(verbose)) {
+            this.verbose = options.valueOf(verbose);
+        }
     }
-  }
+
+    private void createOutputDirectories() {
+        try {
+            Files.createDirectories(this.outputDir);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void beforeIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams) {
+        if (!warmupStarted) {
+            jcmd(benchmarkParams.getJvm(), "VM.unlock_commercial_features", Collections.emptyList());
+            name = "JMH-profile-" + benchmarkParams.getBenchmark().replaceAll("\\s+", "-");
+            startJfr(benchmarkParams);
+            warmupStarted = true;
+        }
+        if (!started && iterationParams.getType() == IterationType.MEASUREMENT) {
+            stopDiscardJfr(benchmarkParams);
+            startJfr(benchmarkParams);
+            started = true;
+        }
+    }
+
+    private void stopDiscardJfr(BenchmarkParams benchmarkParams) {
+        ArrayList<String> options = new ArrayList<>();
+        options.add("name=" + name);
+        options.add("discard=true");
+        jcmd(benchmarkParams.getJvm(), "JFR.stop", options);
+    }
+
+    private void startJfr(BenchmarkParams benchmarkParams) {
+        ArrayList<String> options = new ArrayList<>();
+        options.add("name=" + name);
+        options.addAll(flightRecorderOptions);
+        jcmd(benchmarkParams.getJvm(), "JFR.start", options);
+    }
+
+    @Override
+    public Collection<? extends Result> afterIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams, IterationResult result) {
+        if (iterationParams.getType() == IterationType.MEASUREMENT) {
+            measurementIterationCount += 1;
+            if (measurementIterationCount == iterationParams.getCount()) {
+                if (outputDir == null) {
+                    outputDir = createTempDir(benchmarkParams.id().replaceAll("/", "-"));
+                }
+
+                ArrayList<String> options = new ArrayList<>();
+
+                options.add("name=" + name);
+                Path jfrDump = outputDir.resolve(PROFILE_JFR);
+                options.add("filename=" + jfrDump.toAbsolutePath().toString());
+                jcmd(benchmarkParams.getJvm(), "JFR.stop", options);
+                generated.add(jfrDump);
+                for (JfrEventType event: events) {
+                    String eventName = event.name().toLowerCase().replace('_', '-');
+                    Path collapsed = createCollapsed(eventName);
+                    generated.add(collapsed);
+                    if (jfrFlameGraphDir != null) {
+                        if (EnumSet.of(Directions.FORWARD, Directions.BOTH).contains(directions)) {
+                            jfrFlameGraph(collapsed, Collections.emptyList(), "", eventName);
+                        }
+                        if (EnumSet.of(Directions.REVERSE, Directions.BOTH).contains(directions)) {
+                            jfrFlameGraph(collapsed, Arrays.asList("--reverse"), "-reverse", eventName);
+                        }
+                    }
+                }
+            }
+        }
+
+        return Collections.singletonList(result());
+    }
+
+    private void jfrFlameGraph(Path collapsed, List<String> extra, String suffix, String eventName) {
+        generated.add(ProfilerUtils.flameGraph(collapsed, extra, suffix, flameGraphDir, flameGraphOpts, outputDir, eventName, verbose));
+    }
+
+    private Path createCollapsed(String eventName) {
+        ArrayList<String> args = new ArrayList<>();
+        args.add("bash");
+        args.add("-e");
+        args.add(jfrFlameGraphDir.resolve("flamegraph-output.sh").toAbsolutePath().toString());
+        args.add("--output-type");
+        args.add("folded");
+        args.add("--jfrdump");
+        args.add(outputDir.resolve(PROFILE_JFR).toAbsolutePath().toString());
+        args.add("--event");
+        args.add(eventName);
+        Path outFile = outputDir.resolve("jfr-collapsed-cpu.txt");
+        args.add("--output");
+        args.add(outFile.toAbsolutePath().toString());
+        args.addAll(jfrFlameGraphOpts);
+        ProcessBuilder processBuilder = new ProcessBuilder(args);
+        if (verbose) {
+            processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        }
+        ProfilerUtils.startAndWait(processBuilder, verbose);
+        return outFile;
+    }
+
+
+    private NoResult result() {
+        StringBuilder result = new StringBuilder();
+        for (Path path : generated) {
+            result.append("\n").append(path.toAbsolutePath().toString());
+        }
+        return new NoResult("JFR", result.toString());
+    }
+
+    private void jcmd(String jvm, String command, List<String> options) {
+        long pid = Utils.getPid();
+        ArrayList<String> args = new ArrayList<>();
+        Path jcmd = findJcmd(jvm);
+
+        args.add(jcmd.toAbsolutePath().toString());
+        args.add(String.valueOf(pid));
+        args.add(command);
+        args.addAll(options);
+        ProcessBuilder processBuilder = new ProcessBuilder(args);
+        if (verbose) {
+            processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        }
+        ProfilerUtils.startAndWait(processBuilder, verbose);
+    }
+
+    private Path findJcmd(String jvm) {
+        Path jcmd;
+        Path firstTry = Paths.get(jvm.replaceAll("java", "jcmd"));
+        if (Files.exists(firstTry)) {
+            jcmd = firstTry;
+        } else {
+            jcmd = Paths.get(jvm.replace("jre/bin/java", "bin/jcmd"));
+        }
+        return jcmd;
+    }
+
+    private Path createTempDir(String name) {
+        try {
+            return Files.createTempDirectory(name);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return "Java Flight Recording profiler runs for every benchmark.";
+    }
+
+    @Override
+    public Collection<String> addJVMInvokeOptions(BenchmarkParams params) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<String> addJVMOptions(BenchmarkParams params) {
+
+        List<String> args = new ArrayList<>();
+        args.add("-XX:FlightRecorderOptions=samplethreads=true,stackdepth=" + stackDepth);
+        if (debugNonSafepoints) {
+            args.add("-XX:+UnlockDiagnosticVMOptions");
+            args.add("-XX:+DebugNonSafepoints");
+        }
+        return args;
+
+    }
+
+    @Override
+    public void beforeTrial(BenchmarkParams benchmarkParams) {
+    }
+
+    @Override
+    public Collection<? extends Result> afterTrial(BenchmarkResult br, long pid, File stdOut, File stdErr) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean allowPrintOut() {
+        return true;
+    }
+
+    @Override
+    public boolean allowPrintErr() {
+        return true;
+    }
 }

--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/JfrEventType.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/JfrEventType.java
@@ -1,0 +1,5 @@
+package pl.project13.scala.jmh.extras.profiler;
+
+public enum JfrEventType {
+    CPU, ALLOCATION_TLAB, ALLOCATION_OUTSIDE_TLAB, EXCEPTIONS, LOCKS
+}

--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/NoResult.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/NoResult.java
@@ -1,0 +1,63 @@
+package pl.project13.scala.jmh.extras.profiler;
+
+import org.openjdk.jmh.results.AggregationPolicy;
+import org.openjdk.jmh.results.Aggregator;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.ResultRole;
+import org.openjdk.jmh.util.Statistics;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+class NoResult extends Result<NoResult> {
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+    private String name;
+    private final LinkedHashSet<String> output;
+
+    public NoResult(String name, String output) {
+        this(name, singletonSet(output));
+
+    }
+
+    public NoResult(String name, LinkedHashSet<String> output) {
+        super(ResultRole.SECONDARY, name, of(Double.NaN), "N/A", AggregationPolicy.SUM);
+        this.name = name;
+        this.output = output;
+    }
+
+    private static LinkedHashSet<String> singletonSet(String s) {
+        LinkedHashSet<String> strings = new LinkedHashSet<>();
+        strings.add(s);
+        return strings;
+    }
+
+    @Override
+    protected Aggregator<NoResult> getThreadAggregator() {
+        return new NoResultAggregator();
+    }
+
+    @Override
+    protected Aggregator<NoResult> getIterationAggregator() {
+        return new NoResultAggregator();
+    }
+
+    @Override
+    public String extendedInfo() {
+        StringBuilder out = new StringBuilder();
+        for (String s : output) {
+            out.append(s).append(LINE_SEPARATOR);
+        }
+        return out.toString();
+    }
+
+    private class NoResultAggregator implements Aggregator<NoResult> {
+        @Override
+        public NoResult aggregate(Collection<NoResult> results) {
+            LinkedHashSet<String> strings = new LinkedHashSet<>();
+            for (NoResult r : results) {
+                strings.addAll(r.output);
+            }
+            return new NoResult(name, strings);
+        }
+    }
+}

--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/ProfilerUtils.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/ProfilerUtils.java
@@ -1,0 +1,83 @@
+package pl.project13.scala.jmh.extras.profiler;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import org.openjdk.jmh.profile.ProfilerException;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ProfilerUtils {
+    static final String FLAME_GRAPH_DIR = "FLAME_GRAPH_DIR";
+
+    public static OptionSet parseInitLine(String initLine, OptionParser parser) throws ProfilerException {
+        try {
+            Method method = Class.forName("org.openjdk.jmh.profile.ProfilerUtils").getDeclaredMethod("parseInitLine", String.class, OptionParser.class);
+            method.setAccessible(true);
+            return (OptionSet) method.invoke(null, initLine, parser);
+        } catch (InvocationTargetException ex) {
+            throw (ProfilerException) ex.getCause();
+        } catch (NoSuchMethodException | IllegalArgumentException | IllegalAccessException | ClassNotFoundException | SecurityException e) {
+            throw new ProfilerException(e);
+        }
+    }
+
+    static void startAndWait(ProcessBuilder processBuilder, boolean verbose) {
+        String commandLine = processBuilder.command().stream().collect(Collectors.joining(" "));
+        try {
+            processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+            if (verbose) System.out.println(commandLine);
+            Process process = processBuilder.start();
+            if (process.waitFor() != 0) {
+                throw new RuntimeException("Non zero exit code from: " + commandLine);
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Error running " + commandLine, e);
+        }
+    }
+
+    static void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static Path flameGraph(Path collapsedPath, List<String> extra, String suffix, Path flameGraphHome, Collection<? extends String> flameGraphOptions, Path outputDir, String eventName, boolean verbose) {
+        ArrayList<String> args = new ArrayList<>();
+        args.add("perl");
+        args.add(flameGraphHome.resolve("flamegraph.pl").toAbsolutePath().toString());
+        args.addAll(flameGraphOptions);
+        args.addAll(extra);
+        args.add(collapsedPath.toAbsolutePath().toString());
+        Path outputFile = outputDir.resolve("flame-graph-" + eventName + suffix + ".svg");
+        startAndWait(new ProcessBuilder(args).redirectOutput(outputFile.toFile()), verbose);
+        return outputFile;
+    }
+
+    static OptionSpec<String> addFlameGraphDirOption(OptionParser parser) {
+        return parser.accepts("flameGraphDir", "Location of clone of https://github.com/brendangregg/FlameGraph. Also can be provided as $" + ProfilerUtils.FLAME_GRAPH_DIR).withRequiredArg().ofType(String.class).describedAs("directory");
+    }
+
+    static Path findFlamegraphDir(OptionSpec<String> flameGraphDir, OptionSet options) {
+        String flameGraphHome = System.getenv(FLAME_GRAPH_DIR);
+        if (options.has(flameGraphDir)) {
+            return Paths.get(options.valueOf(flameGraphDir));
+        } else {
+            if (flameGraphHome != null) {
+                return Paths.get(flameGraphHome);
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/plugin/src/sbt-test/sbt-jmh/with-FlightRecorderProfiler/test
+++ b/plugin/src/sbt-test/sbt-jmh/with-FlightRecorderProfiler/test
@@ -1,5 +1,5 @@
 > show libraryDependencies
-> jmh:run -prof jmh.extras.JFR -i 5 -wi 1 -f 1 .*Hello.*
+> jmh:run -prof jmh.extras.JFR:dir=. -i 5 -wi 1 -f 1 .*Hello.*
 
 # check if the custom file was generated
-$ exists org.openjdk.jmh.samples.JMHSample_01_HelloWorld.wellHelloThere-Throughput-0.jfr
+$ exists profile.jfr


### PR DESCRIPTION
Existing Flight Recorder profiler modified to:

  - Discard samples collected during the warmup period
  - By default, use AsyncGetCallTrace based sampling
  - Make `stackdepth` configurable and increase the default
  - Optionally, generate flamegraphs for (requires local clone of
    [brendangregg/FlameGraph](https://github.com/brendangregg/FlameGraph) and a local clone and build of
    [chrishantha/jfr-flame-graph](https://github.com/chrishantha/jfr-flame-graph).)

Support async-profiler:
  - Requires local clone and build of [jvm-profiling-tools/async-profiler](https://github.com/jvm-profiling-tools/async-profiler)
  - Samples only collected after warmup has completed
  - CPU and HEAP events supported.
  - Optionally, generate flame graphs

async-profiler is primarily Linux based, but it also has preliminary support for MacOS.

The location of the external tools can be provided with the followng environment
variables: `FLAME_GRAPH_DIR`, `JFR_FLAME_GRAPH_DIR`, `ASYNC_PROFILER_DIR`. Alternatively,
these can be provided as options to the profiler.

Help:

```
sbt> jmh:run Bench -prof jmh.extras.JFR:help
Option                              Description
------                              -----------
--debugNonSafepoints <Boolean>      (default: [true, false])
--dir <Output directory>
--events <JfrEventType>             (default: [CPU, ALLOCATION_TLAB,
                                      ALLOCATION_OUTSIDE_TLAB, EXCEPTIONS,
                                      LOCKS])
--flameGraphDir <directory>       Location of clone of https://github.
                                      com/brendangregg/FlameGraph. Also
                                      can be provided as $FLAME_GRAPH_DIR
--flameGraphDirection <Directions>  Directions to generate flamegraphs
--flameGraphOpts                    Options passed to FlameGraph.pl
--flightRecorderOpts
--help                              Display help.
--jfrFlameGraphDir <directory>    Location of clone of https://github.
                                      com/chrishantha/jfr-flame-graph.
                                      Also can be provided as
                                      $JFR_FLAME_GRAPH_DIR
--jfrFlameGraphOpts                 Options passed to flamegraph-output.sh
--stackDepth <Integer>              (default: 1024)
--verbose <Boolean>                 Output the sequence of commands
                                      (default: false)

```

```
sbt> jmh:run Bench -prof jmh.extras.Async:help

Option                              Description
------                              -----------
--asyncProfilerDir <directory>    Location of clone of https://github.
                                      com/jvm-profiling-tools/async-
                                      profiler. Also can be provided as
                                      $ASYNC_PROFILER_DIR
--dir <<directory>>                 Output directory
--event <AsyncProfilerEventType>    Event to sample (default: [CPU, HEAP])
--flameGraphDir <directory>       Location of clone of https://github.
                                      com/brendangregg/FlameGraph. Also
                                      can be provided as $FLAME_GRAPH_DIR
--flameGraphDirection <Directions>  Directions to generate flamegraphs
                                      (default: [BOTH, NONE, FORWARD,
                                      REVERSE])
--flameGraphOpts                    Options passed to FlameGraph.pl
--framebuf <Long>                   Size of profiler framebuffer (default:
                                      8388608)
--help                              Display help.
--threads <Boolean>                 profile threads separately (default:
                                      [false, true])
--verbose <Boolean>                 Output the sequence of commands
                                      (default: false)

```

Examples:

```
sbt> jmh:run Bench -f1 -wi 5 -i5 -prof jmh.extras.Async:event=HEAP;dir=/tmp/profile-async;flameGraphOpts=--minwidth,2;asyncProfilerDir=/code/async-profiler;flameGraphDir=/code/FlameGraph

sbt> jmh:run Bench -f1 -wi 5 -i5 -prof jmh.extras.JFR:dir=/tmp/profile-jfr;flameGraphDir=/code/FlameGraph;jfrFlameGraphDir=/code/jfr-flame-graph;flameGraphOpts=--minwidth,2;verbose=true
```
