### PR TITLE
Update benchmark in `src/test` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ classDirectory in Jmh := (classDirectory in Test).value
 dependencyClasspath in Jmh := (dependencyClasspath in Test).value
 // rewire tasks, so that 'jmh:run' automatically invokes 'jmh:compile' (otherwise a clean 'jmh:run' would fail)
 compile in Jmh := (compile in Jmh).dependsOn(compile in Test).value
-run in Jmh := (run in Jmh).dependsOn(Keys.compile in Jmh).value
+run in Jmh := (run in Jmh).dependsOn(Keys.compile in Jmh).evaluated
 ```
 
 Options


### PR DESCRIPTION
Newer version of sbt expect `evaluated` instead of `value` on `InputKey`
http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html#Migrating+with