### PR TITLE
Improvements to profilers

### DIFF
--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/AsyncProfiler.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/AsyncProfiler.java
@@ -161,6 +161,9 @@ public class AsyncProfiler implements InternalProfiler, ExternalProfiler {
     public void beforeIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams) {
         if (!started && iterationParams.getType() == IterationType.MEASUREMENT) {
             String threadOpt = this.threads ? ",threads" : "";
+            if (outputDir == null) {
+                outputDir = createTempDir(benchmarkParams.id().replaceAll("/", "-"));
+            }
             String jfrOpt = this.jfr ? ",jfr,file=" + jfrFile().toAbsolutePath().toString() : "";
             profilerCommand(String.format("start,event=%s%s%s,framebuf=%d,interval=%d", event, jfrOpt, threadOpt, framebuf, interval));
             started = true;
@@ -172,9 +175,6 @@ public class AsyncProfiler implements InternalProfiler, ExternalProfiler {
         if (iterationParams.getType() == IterationType.MEASUREMENT) {
             measurementIterationCount += 1;
             if (measurementIterationCount == iterationParams.getCount()) {
-                if (outputDir == null) {
-                    outputDir = createTempDir(benchmarkParams.id().replaceAll("/", "-"));
-                }
                 if (jfr) {
                     Path jfrDump = jfrFile();
                     generated.add(jfrDump);

--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
@@ -145,7 +145,11 @@ public class FlightRecordingProfiler implements InternalProfiler, ExternalProfil
     @Override
     public void beforeIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams) {
         if (!warmupStarted) {
-            jcmd(benchmarkParams.getJvm(), "VM.unlock_commercial_features", Collections.emptyList());
+            try {
+                jcmd(benchmarkParams.getJvm(), "VM.unlock_commercial_features", Collections.emptyList());
+            } catch (Throwable t) {
+                // ignore, we might be running on OpenJDK 11
+            }
             name = "JMH-profile-" + benchmarkParams.getBenchmark().replaceAll("\\s+", "-");
             startJfr(benchmarkParams);
             warmupStarted = true;


### PR DESCRIPTION
- Support Flight Recorder on OpenJDK 11
  - Enable -XX:+DebugNonSafePoints for async-profiler, by default.
  - Add an option to async-profiler to also dump its data in JFR format.

Fixes #156