### PR TITLE
Adopt best practices in Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,12 @@ sudo: false
 language: scala
 script: sbt '; extras/publishLocal; project plugin; ^scripted'
 jdk:
- - oraclejdk8
+  - oraclejdk8
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+before_cache:
+  # Cleanup the cached directories to avoid unnecessary cache updates
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete


### PR DESCRIPTION
Enable caching of SBT and downloaded artifacts

Use openjdk8 rather than oraclejdk.