### PR TITLE
Use dist:trusty for pre-installed OracleJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: scala
 script: sbt '; extras/publishLocal; project plugin; ^scripted'
 jdk:


### PR DESCRIPTION
Fixes #168