### PR TITLE
Add benchmark method name to output JFR filename

### DIFF
--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
@@ -223,7 +223,7 @@ public class FlightRecordingProfiler implements InternalProfiler, ExternalProfil
                 ArrayList<String> options = new ArrayList<>();
 
                 options.add("name=" + name);
-                Path jfrDump = outputDir.resolve(PROFILE_JFR);
+                Path jfrDump = outputDir.resolve(benchmarkParams.getBenchmark() + "-" + PROFILE_JFR);
                 options.add("filename=" + jfrDump.toAbsolutePath().toString());
                 jcmd(benchmarkParams.getJvm(), "JFR.stop", options);
                 generated.add(jfrDump);


### PR DESCRIPTION
The readme seems to indicate that JFR files contain their names, but they seem hard coded to "profile.jfr" (https://github.com/ktoso/sbt-jmh/blob/master/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java#L36).

This change prefixes the name with the current benchmark, so each benchmark method gets its own profile jfr output.

I see that it used to support params as well in https://github.com/ktoso/sbt-jmh/blame/d70cd26695e14392fed65032cab42359c48c103d/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java#L100.