### PR TITLE
Add benchmark method name to output JFR filename 

### DIFF
--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
@@ -223,7 +223,8 @@ public class FlightRecordingProfiler implements InternalProfiler, ExternalProfil
                 ArrayList<String> options = new ArrayList<>();
 
                 options.add("name=" + name);
-                Path jfrDump = outputDir.resolve(PROFILE_JFR);
+                String params = benchmarkParams.id().replaceAll("/", "-");
+                Path jfrDump = outputDir.resolve(params + "-" + PROFILE_JFR);
                 options.add("filename=" + jfrDump.toAbsolutePath().toString());
                 jcmd(benchmarkParams.getJvm(), "JFR.stop", options);
                 generated.add(jfrDump);

--- a/plugin/src/sbt-test/sbt-jmh/with-FlightRecorderProfiler/test
+++ b/plugin/src/sbt-test/sbt-jmh/with-FlightRecorderProfiler/test
@@ -2,4 +2,4 @@
 > jmh:run -prof jmh.extras.JFR:dir=. -i 5 -wi 1 -f 1 .*Hello.*
 
 # check if the custom file was generated
-$ exists profile.jfr
+$ exists org.openjdk.jmh.samples.JMHSample_01_HelloWorld.wellHelloThere-Throughput-profile.jfr


### PR DESCRIPTION
Better version of #171.

The readme seems to indicate that JFR files contain their names, but they seem hard coded to "profile.jfr" (https://github.com/ktoso/sbt-jmh/blob/master/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java#L36).

This change prefixes the name with the current benchmark params, so each benchmark method gets its own profile jfr output.

I see that it used to support params as well in https://github.com/ktoso/sbt-jmh/blame/d70cd26695e14392fed65032cab42359c48c103d/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java#L100.

Now including update to test.