### PR TITLE
Make profilers discoverable by JMH:

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,12 @@ Option                              Description
                                       (default: false)
 ```
 
-### Automatically generating flame-grapghs
+### Using Profilers with non-SBT Projects
+
+Both JFR and Async Profiler JMH integrations are shipped in a separate Java library,
+compatible with any JMH benchmark. See the [module readme](extras/README.md) for details.
+
+### Automatically generating flame-graphs
 
 Read more about flame graphs here:
 

--- a/extras/README.md
+++ b/extras/README.md
@@ -1,0 +1,60 @@
+# Extra JMH Profilers
+
+![Maven Central](https://img.shields.io/maven-central/v/pl.project13.scala/sbt-jmh-extras)
+
+This library contains JMH integrations for the following profiler tools:
+  * Java Flight Recorder.
+  * [Async Profiler](https://github.com/jvm-profiling-tools/async-profiler/).
+  
+## Usage
+
+The JMH profilers do not require SBT and can be used by _any_ JMH benchmark:
+
+1. Add a compile dependency on `pl.project13.scala:sbt-jmh-extras`
+2. Build the project
+3. Verify that the profiler integrations are loaded by listing
+   the available implementations with `-lprof` flag.
+
+Please note that the profiler tools need to be installed separately,
+they are not distributed with this library.
+
+### Maven Example
+
+Add a dependency:
+
+```xml
+<dependency>
+  <groupId>pl.project13.scala</groupId>
+  <artifactId>sbt-jmh-extras</artifactId>
+  <version>VERSION</version>
+</dependency>
+```
+
+Build the benchmark project:
+
+```sh
+mvn clean package
+```
+
+Verify the profilers are discovered:
+
+```sh
+java -jar target/benchmarks.jar -lprof
+```
+
+<details>
+
+<summary>Expected output:</summary>
+
+```
+Supported profilers:
+                                                              cl: Classloader profiling via standard MBeans 
+                                                            comp: JIT compiler profiling via standard MBeans 
+                                                              gc: GC profiling via standard MBeans 
+                                                                 ⋮
+                                                           stack: Simple and naive Java stack profiler 
+            pl.project13.scala.jmh.extras.profiler.AsyncProfiler: Profiling using async-profiler (discovered)
+  pl.project13.scala.jmh.extras.profiler.FlightRecordingProfiler: Java Flight Recording profiler runs for every benchmark. (discovered)
+```
+
+</details>

--- a/extras/README.md
+++ b/extras/README.md
@@ -30,6 +30,33 @@ Add a dependency:
 </dependency>
 ```
 
+It is also recommended to add a ServicesResourceTransformer to the shade plugin configuration
+to ensure reliable detection in the presence of other profiler providers:
+
+```xml
+  <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-shade-plugin</artifactId>
+    <version>3.2.1</version>
+    <executions>
+      <execution>
+        <phase>package</phase>
+        <goals>
+          <goal>shade</goal>
+        </goals>
+        <configuration>
+          <transformers>
+            <!-- ¡Add this transformer if not already present: -->
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+            <!-- Keep the other transformers -->
+          </transformers>
+          <!-- and the rest of the configuration -->
+        </configuration>
+      </execution>
+    </executions>
+  </plugin>
+```
+
 Build the benchmark project:
 
 ```sh

--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
@@ -55,6 +55,18 @@ public class FlightRecordingProfiler implements InternalProfiler, ExternalProfil
     private int stackDepth;
     private List<Path> generated = new ArrayList<>();
 
+    /**
+     * Creates a JFR profiler with an empty command line. This constructor is required
+     * so that {@link ServiceLoader} can instantiate this class as an implementation
+     * of {@link org.openjdk.jmh.profile.Profiler} interface. The instance will <em>not</em>
+     * be used by JMH for anything but getting its class name.
+     *
+     * @see org.openjdk.jmh.profile.ProfilerFactory
+     */
+    public FlightRecordingProfiler() throws ProfilerException {
+        this("");
+    }
+
     public FlightRecordingProfiler(String initLine) throws ProfilerException {
         OptionParser parser = new OptionParser();
         OptionSpec<String> outputDir = parser.accepts("dir").withRequiredArg().describedAs("Output directory").ofType(String.class);

--- a/extras/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
+++ b/extras/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
@@ -1,0 +1,3 @@
+# The implementations of JMH Profiler provided by the library:
+pl.project13.scala.jmh.extras.profiler.AsyncProfiler
+pl.project13.scala.jmh.extras.profiler.FlightRecordingProfiler


### PR DESCRIPTION
Make the profilers shipped in sbt-jmh-extras discoverable by JMH,
by specifying the provided implementations of Profiler interface
and adding a no-arg constructor, required by the ServiceLoader.