### PR TITLE
minor fix to jcmd lookup

### DIFF
--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
@@ -308,7 +308,7 @@ public class FlightRecordingProfiler implements InternalProfiler, ExternalProfil
 
     private Path findJcmd(String jvm) {
         Path jcmd;
-        Path firstTry = Paths.get(jvm.replaceAll("java", "jcmd"));
+        Path firstTry = Paths.get(jvm).resolveSibling("jcmd");
         if (Files.exists(firstTry)) {
             jcmd = firstTry;
         } else {


### PR DESCRIPTION
`replaceAll` causes on most environments weird behaviour, cause it fails to find jcmd