### PR TITLE
#180 Fix flight recorder profiler's jcmd resolution

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-import bintray.Keys._
 import java.io.FileInputStream
 import java.util.Properties
+import _root_.bintray.BintrayPlugin.bintrayPublishSettings
 
 val jmhVersion = {
   val props = new Properties()
@@ -74,11 +74,6 @@ val sonatypeSettings: Seq[Setting[_]] = Seq(
     </parent>
   )
 
-// sbt-scripted settings
-val myScriptedSettings = scriptedSettings ++ Seq(
-  scriptedLaunchOpts += s"-Dproject.version=${version.value}"
-) 
-
 // ---------------------------------------------------------------------------------------------------------------------
 
 lazy val root =
@@ -90,23 +85,24 @@ lazy val root =
 lazy val plugin = project
   .in(file("plugin"))
   .settings(commonSettings: _*)
-  .settings(myScriptedSettings: _*)
+  .enablePlugins(ScriptedPlugin)
+  .settings(scriptedLaunchOpts += s"-Dproject.version=${version.value}")
   .settings(
     name := "sbt-jmh",
     
     sbtPlugin := true,
     publishTo := {
       if (isSnapshot.value)
-        Some(Classpaths.sbtPluginSnapshots)
+        Some(Resolver.sbtPluginRepo("snapshots"))
       else
-        Some(Classpaths.sbtPluginReleases)
+        Some(Resolver.sbtPluginRepo("releases"))
     },
     publishMavenStyle := false,
     startYear := Some(2014),
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
     bintrayPublishSettings,
-    repository in bintray := "sbt-plugins",
-    bintrayOrganization in bintray := None
+    bintray / bintrayRepository := "sbt-plugins",
+    bintray / bintrayOrganization := None
   ).dependsOn(extras)
   .enablePlugins(AutomateHeaderPlugin)
 

--- a/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
+++ b/extras/src/main/java/pl/project13/scala/jmh/extras/profiler/FlightRecordingProfiler.java
@@ -312,7 +312,7 @@ public class FlightRecordingProfiler implements InternalProfiler, ExternalProfil
         if (Files.exists(firstTry)) {
             jcmd = firstTry;
         } else {
-            jcmd = Paths.get(jvm.replace("jre/bin/java", "bin/jcmd"));
+            jcmd = Paths.get(jvm.replace("bin/java$", "bin/jcmd"));
         }
         return jcmd;
     }

--- a/plugin/src/main/resources/sbt-jmh.properties
+++ b/plugin/src/main/resources/sbt-jmh.properties
@@ -1,2 +1,2 @@
-jmh.version=1.22
+jmh.version=1.23
 extras.version=0.3.8-SNAPSHOT

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "2.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
`jcmd` resolution was failing on my computer because the root of JDK installation was not named `jre` (it is a system JRE installation that I haven't named myself). As a result the following code
```
jcmd = Paths.get(jvm.replace("jre/bin/java", "bin/jcmd"));
```
didn't match-replace which resulted in a wrong process running, so I replaced it with:

```
jcmd = Paths.get(jvm.replace("bin/java$", "bin/jcmd"));
```

In the process or figuring out how to `publishLocal` for sbt 1.0 I updated the build configuration, so this PR will most likely require some polishing about: publishing and/or running scripted tests.