### PR TITLE
Drop SBT 0.13.x support and update SBT plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Versions
 
 | Plugin version                     | JMH version & other information       | 
 | ---------------------------------- |:-------------------------------------:|
-| `0.4.0`  (sbt 0.13.17 / sbt 1.1.4) | `1.25`, profilers now in JMH core     | 
+| `0.4.0`  (sbt 1.3.0+)              | `1.25`, profilers now in JMH core     | 
 | `0.3.7`  (sbt 0.13.17 / sbt 1.1.4) | `1.21`, support JDK 11                | 
 | `0.3.6`  (sbt 0.13.17 / sbt 1.1.4) | `1.21`, support JDK 11                |
 | `0.3.4`  (sbt 0.13.17 / sbt 1.1.4) | `1.21`, support of GraalVM            |

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import bintray.Keys._
 import java.io.FileInputStream
 import java.util.Properties
 
@@ -13,7 +12,7 @@ val jmhVersion = {
 val commonSettings = Seq(
   organization := "pl.project13.scala",
 
-  crossSbtVersions := Vector("1.2.1", "0.13.17"),
+  crossSbtVersions := Vector("1.3.0"),
 
   scalacOptions ++= List(
     "-unchecked",
@@ -36,7 +35,7 @@ val commonSettings = Seq(
 )
 
 // sbt-scripted settings
-val myScriptedSettings = scriptedSettings ++ Seq(
+val myScriptedSettings = Seq(
   scriptedLaunchOpts += s"-Dproject.version=${version.value}"
 ) 
 
@@ -51,21 +50,16 @@ lazy val root =
 lazy val plugin = project
   .in(file("plugin"))
   .settings(commonSettings: _*)
+  .enablePlugins(SbtPlugin)
   .settings(myScriptedSettings: _*)
   .settings(
     name := "sbt-jmh",
-    
     sbtPlugin := true,
-    publishTo := {
-      if (isSnapshot.value)
-        Some(Classpaths.sbtPluginSnapshots)
-      else
-        Some(Classpaths.sbtPluginReleases)
-    },
+    publishTo := Some(Classpaths.sbtPluginReleases),
     publishMavenStyle := false,
     startYear := Some(2014),
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-    bintrayPublishSettings,
-    repository in bintray := "sbt-plugins",
-    bintrayOrganization in bintray := None
+    bintrayRepository := "sbt-plugins",
+    bintrayOrganization := None,
+    bintrayPackageLabels := Seq("sbt-plugin", "jmh", "benchmarking")
   ).enablePlugins(AutomateHeaderPlugin)

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,2 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "2.0.0")
-
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")

--- a/sbt-jmh-tester/project/plugins.sbt
+++ b/sbt-jmh-tester/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % {
   val is = io.Source.fromFile(new File("../version.sbt")).mkString
   val it = is.replaceAll("version in ThisBuild := ", "").replaceAll("\"", "").replaceAll("\n", "")
   it
-}, "0.13", "2.10")
+}, "1.3", "2.12")


### PR DESCRIPTION
As part of the 0.4.0 release, lets mandate SBT 1.3.x.