### PR TITLE
Fails to load resources

### DIFF
--- a/sbt-jmh-tester/src/main/scala/test/TestBenchmark.scala
+++ b/sbt-jmh-tester/src/main/scala/test/TestBenchmark.scala
@@ -21,11 +21,13 @@ class TestBenchmark {
       .count(_.toString.length == 4)
 
   @Benchmark
-  def readFromFile(): Int =
-    helloFile.getLines()
+  def readFromFile(): Int = {
+    val actual = helloFile.getLines()
       .map(_.length)
       .sum
-}
+    assert(actual > 0)
+    actual
+  }
 
 object TestBenchmark {
   val helloFile = Source.fromInputStream(getClass.getClassLoader.getResourceAsStream("hello.txt"))


### PR DESCRIPTION
It looks like sbt-jmh fails to load resource file. I added a assert line that verifies that loaded resource content isn't empty. It fails.
Run with
```
sbt "jmh:run -i 1 -wi 0 -f1 -t1 .*TestBenchmark.readFromFile"
```
Outputs:
```
[info] # JMH version: 1.25
[info] # VM version: JDK 1.8.0_232, OpenJDK 64-Bit Server VM, 25.232-b09
[info] # VM invoker: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/bin/java
[info] # VM options: <none>
[info] # Warmup: <none>
[info] # Measurement: 1 iterations, 10 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 1 thread, will synchronize iterations
[info] # Benchmark mode: Throughput, ops/time
[info] # Benchmark: test.TestBenchmark.readFromFile
[info] # Run progress: 0.00% complete, ETA 00:00:10
[info] # Fork: 1 of 1
[info] Iteration   1: <failure>
[info] java.lang.AssertionError: assertion failed
[info]  at scala.Predef$.assert(Predef.scala:204)
[info]  at test.TestBenchmark.readFromFile(TestBenchmark.scala:28)
[info]  at test.jmh_generated.TestBenchmark_readFromFile_jmhTest.readFromFile_thrpt_jmhStub(TestBenchmark_readFromFile_jmhTest.java:119)
[info]  at test.jmh_generated.TestBenchmark_readFromFile_jmhTest.readFromFile_Throughput(TestBenchmark_readFromFile_jmhTest.java:83)
[info]  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[info]  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[info]  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[info]  at java.lang.reflect.Method.invoke(Method.java:498)
[info]  at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
[info]  at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
[info]  at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info]  at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[info]  at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info]  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[info]  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[info]  at java.lang.Thread.run(Thread.java:748)
[info] # Run complete. Total time: 00:00:00
```