### PR TITLE
Update release-drafter.yml

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: release-drafter/release-drafter@v6
         env:


### PR DESCRIPTION
ubuntu-20.04 is no more, I think.
<img width="1282" height="546" alt="Release_Drafter_·_Workflow_runs_·_sbt_sbt-jmh" src="https://github.com/user-attachments/assets/903493c0-76b8-4d76-b61e-c1b979cfc1a9" />
